### PR TITLE
Increased rate limit from 10 to 500 for PublicAPI & added code handle rate limit

### DIFF
--- a/api/ratelimiter.go
+++ b/api/ratelimiter.go
@@ -18,7 +18,7 @@ type visitors struct {
 }
 
 func (v *visitors) addVisitor(ip string) *rate.Limiter {
-	limiter := rate.NewLimiter(5, 10)
+	limiter := rate.NewLimiter(5, 500)
 	v.lock.Lock()
 	v.visitors[ip] = &visitor{limiter, time.Now()}
 	v.lock.Unlock()
@@ -43,7 +43,7 @@ func (v *visitors) cleanupVisitors() {
 		time.Sleep(time.Minute)
 		v.lock.Lock()
 		for ip, visitor := range v.visitors {
-			if time.Now().Sub(visitor.lastSeen) > 3 * time.Minute {
+			if time.Now().Sub(visitor.lastSeen) > 3*time.Minute {
 				delete(v.visitors, ip)
 			}
 		}


### PR DESCRIPTION
- Increased rate limit from 10 to 500 for PublicAPI
- Re-request balance after sleep/delay when rate limit is hit

Fix for the issue #285 