### PR TITLE
Fix: Removed command to create devnet directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
       - run: go build ./cmd/zond-cli
       - run: ./zond-cli dev genesis-bootstrap
       - run: mkdir ~/.zond
-      - run: mkdir block/genesis/devnet
       - run: cp bootstrap/prestate.yml ./block/genesis/devnet/
       - run: cp bootstrap/genesis.yml ./block/genesis/devnet/
       - run: cp bootstrap/dilithium_keys ~/.zond


### PR DESCRIPTION
Removed command to create devnet directory as it already exists.